### PR TITLE
Add Infisical secrets manager application

### DIFF
--- a/apps/infisical/README.md
+++ b/apps/infisical/README.md
@@ -31,6 +31,8 @@ The `infisical-secret` ExternalSecret pulls these keys from the
 | `INFISICAL_AUTH_SECRET` | `openssl rand -base64 32` |
 | `INFISICAL_POSTGRES_USER` | any value, e.g. `infisical` |
 | `INFISICAL_POSTGRES_PASSWORD` | `openssl rand -base64 24` |
+| `INFISICAL_SMTP_USERNAME` | Resend SMTP username — literally `resend` |
+| `INFISICAL_SMTP_PASSWORD` | Resend API key (`re_...`) |
 
 > ⚠️ `ENCRYPTION_KEY` and `AUTH_SECRET` must remain **stable** for the life of
 > the instance. Rotating `ENCRYPTION_KEY` makes existing encrypted data
@@ -38,6 +40,14 @@ The `infisical-secret` ExternalSecret pulls these keys from the
 
 `DB_CONNECTION_URI` and `REDIS_URL` are composed in-manifest from the above
 secret + the ConfigMap, so they are not stored in Doppler.
+
+### Email (SMTP)
+
+Outbound email is sent via Resend (`smtp.resend.com:587`). The host, port,
+`SMTP_FROM_ADDRESS` (`infisical@support.hoytlabs.app`) and `SMTP_FROM_NAME`
+live in `configmap.yaml`; only the username/password are pulled from Doppler.
+Ensure the `support.hoytlabs.app` domain is verified in Resend so mail from
+`infisical@support.hoytlabs.app` is accepted.
 
 ## Prerequisites
 

--- a/apps/infisical/README.md
+++ b/apps/infisical/README.md
@@ -1,0 +1,52 @@
+# Infisical
+
+Self-hosted [Infisical](https://infisical.com) secrets manager, deployed as a
+pure-Kustomize ArgoCD application (no Helm). Auto-discovered by
+`apps/appset.yaml` and served at **https://infisical.hoytlabs.app**.
+
+## Components
+
+| Resource | Image | Notes |
+|----------|-------|-------|
+| `infisical` Deployment | `infisical/infisical:v0.160.7` | Backend + UI on port 8080 (`/api/status` health). Pinned per Infisical's "always pin a version" guidance. |
+| `infisical-postgres` Deployment | `postgres:16-alpine` | Persistent data on NFS (`192.168.86.44:/mnt/tank/db/infisical`). |
+| `infisical-redis` Deployment | `redis:7-alpine` | Ephemeral cache / queue. |
+
+### Database migrations
+
+The standalone Infisical image's entrypoint does **not** run schema migrations.
+They are run explicitly by the `migration` initContainer in `deployment.yaml`
+(`npm run migration:latest`), gated behind a `wait-for-postgres` initContainer.
+This is idempotent and re-runs automatically on every rollout/upgrade, so
+bumping the image tag also applies that version's migrations.
+
+## Required Doppler secrets
+
+The `infisical-secret` ExternalSecret pulls these keys from the
+`doppler-cluster-secret-store`. Add them to Doppler **before** the app syncs:
+
+| Doppler key | How to generate |
+|-------------|-----------------|
+| `INFISICAL_ENCRYPTION_KEY` | `openssl rand -hex 16` |
+| `INFISICAL_AUTH_SECRET` | `openssl rand -base64 32` |
+| `INFISICAL_POSTGRES_USER` | any value, e.g. `infisical` |
+| `INFISICAL_POSTGRES_PASSWORD` | `openssl rand -base64 24` |
+
+> ⚠️ `ENCRYPTION_KEY` and `AUTH_SECRET` must remain **stable** for the life of
+> the instance. Rotating `ENCRYPTION_KEY` makes existing encrypted data
+> unreadable.
+
+`DB_CONNECTION_URI` and `REDIS_URL` are composed in-manifest from the above
+secret + the ConfigMap, so they are not stored in Doppler.
+
+## Prerequisites
+
+- The NFS export `/mnt/tank/db/infisical` must exist on `192.168.86.44`.
+- Wildcard `*.hoytlabs.app` TLS is already terminated at `gateway-external`;
+  external-dns publishes the `infisical.hoytlabs.app` record from the HTTPRoute
+  annotation.
+
+## First-time setup
+
+Once synced and healthy, browse to https://infisical.hoytlabs.app to create the
+initial admin account (the first signup becomes the instance admin).

--- a/apps/infisical/configmap.yaml
+++ b/apps/infisical/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: infisical-config
+  namespace: infisical
+data:
+  NODE_ENV: "production"
+  # Infisical must bind to all interfaces so the in-cluster Service can reach it
+  # (the image defaults HOST to localhost).
+  HOST: "0.0.0.0"
+  PORT: "8080"
+  SITE_URL: "https://infisical.hoytlabs.app"
+  # Disable phone-home telemetry for a self-hosted homelab instance.
+  TELEMETRY_ENABLED: "false"
+  # Database name created by the bundled postgres instance.
+  POSTGRES_DB: "infisical"
+  # In-cluster Redis has no auth; safe to keep in the ConfigMap.
+  REDIS_URL: "redis://infisical-redis:6379"

--- a/apps/infisical/configmap.yaml
+++ b/apps/infisical/configmap.yaml
@@ -16,3 +16,9 @@ data:
   POSTGRES_DB: "infisical"
   # In-cluster Redis has no auth; safe to keep in the ConfigMap.
   REDIS_URL: "redis://infisical-redis:6379"
+  # SMTP (Resend). Credentials (SMTP_USERNAME/SMTP_PASSWORD) come from the
+  # ExternalSecret. Port 587 uses STARTTLS by default.
+  SMTP_HOST: "smtp.resend.com"
+  SMTP_PORT: "587"
+  SMTP_FROM_ADDRESS: "infisical@support.hoytlabs.app"
+  SMTP_FROM_NAME: "Infisical"

--- a/apps/infisical/deployment.yaml
+++ b/apps/infisical/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infisical
+  namespace: infisical
+  labels:
+    app: infisical
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: infisical
+  template:
+    metadata:
+      labels:
+        app: infisical
+    spec:
+      initContainers:
+        # Block startup until the bundled Postgres is accepting connections so
+        # the migration step below doesn't fail on a cold start.
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - "until nc -z infisical-postgres 5432; do echo 'waiting for postgres'; sleep 2; done"
+        # The standalone Infisical entrypoint does NOT run migrations, so we run
+        # them explicitly. This is idempotent and re-runs on every rollout/upgrade.
+        - name: migration
+          image: infisical/infisical:v0.160.7
+          command: ["npm", "run", "migration:latest"]
+          envFrom:
+            - configMapRef:
+                name: infisical-config
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_password
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: infisical-config
+                  key: POSTGRES_DB
+            - name: DB_CONNECTION_URI
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@infisical-postgres:5432/$(POSTGRES_DB)"
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: encryption_key
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: auth_secret
+      containers:
+        - name: infisical
+          image: infisical/infisical:v0.160.7
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: infisical-config
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_password
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: infisical-config
+                  key: POSTGRES_DB
+            - name: DB_CONNECTION_URI
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@infisical-postgres:5432/$(POSTGRES_DB)"
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: encryption_key
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: auth_secret
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/apps/infisical/deployment.yaml
+++ b/apps/infisical/deployment.yaml
@@ -101,6 +101,16 @@ spec:
                 secretKeyRef:
                   name: infisical-secret
                   key: auth_secret
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: smtp_username
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: smtp_password
           readinessProbe:
             httpGet:
               path: /api/status

--- a/apps/infisical/externalsecret.yaml
+++ b/apps/infisical/externalsecret.yaml
@@ -25,3 +25,10 @@ spec:
     - secretKey: postgres_password
       remoteRef:
         key: INFISICAL_POSTGRES_PASSWORD
+    # Resend SMTP credentials (username is literally "resend").
+    - secretKey: smtp_username
+      remoteRef:
+        key: INFISICAL_SMTP_USERNAME
+    - secretKey: smtp_password
+      remoteRef:
+        key: INFISICAL_SMTP_PASSWORD

--- a/apps/infisical/externalsecret.yaml
+++ b/apps/infisical/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: infisical-secret
+  namespace: infisical
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-cluster-secret-store
+  target:
+    name: infisical-secret
+  data:
+    # openssl rand -hex 16
+    - secretKey: encryption_key
+      remoteRef:
+        key: INFISICAL_ENCRYPTION_KEY
+    # openssl rand -base64 32
+    - secretKey: auth_secret
+      remoteRef:
+        key: INFISICAL_AUTH_SECRET
+    - secretKey: postgres_user
+      remoteRef:
+        key: INFISICAL_POSTGRES_USER
+    - secretKey: postgres_password
+      remoteRef:
+        key: INFISICAL_POSTGRES_PASSWORD

--- a/apps/infisical/http-route.yaml
+++ b/apps/infisical/http-route.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: infisical
+  namespace: infisical
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: infisical.hoytlabs.app
+spec:
+  parentRefs:
+    - name: gateway-external
+      namespace: gateway
+  hostnames:
+    - "infisical.hoytlabs.app"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: infisical
+          port: 8080
+          weight: 1

--- a/apps/infisical/kustomization.yaml
+++ b/apps/infisical/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: infisical
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-svc.yaml
+  - redis-deployment.yaml
+  - redis-svc.yaml
+  - deployment.yaml
+  - service.yaml
+  - http-route.yaml

--- a/apps/infisical/namespace.yaml
+++ b/apps/infisical/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infisical

--- a/apps/infisical/postgres-deployment.yaml
+++ b/apps/infisical/postgres-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infisical-postgres
+  namespace: infisical
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: infisical-postgres
+  template:
+    metadata:
+      labels:
+        app: infisical-postgres
+    spec:
+      securityContext:
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: infisical-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-secret
+                  key: postgres_password
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: infisical-postgres-pvc

--- a/apps/infisical/postgres-svc.yaml
+++ b/apps/infisical/postgres-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: infisical-postgres
+  namespace: infisical
+spec:
+  selector:
+    app: infisical-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/apps/infisical/pvc.yaml
+++ b/apps/infisical/pvc.yaml
@@ -6,6 +6,7 @@ provisioner: nfs.csi.k8s.io
 parameters:
   server: "192.168.86.44"
   share: "/mnt/tank/db/infisical"
+  mountOptions: "nolock"
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
 
@@ -14,12 +15,11 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: infisical-postgres-pv
-  namespace: infisical
 spec:
   capacity:
     storage: 10Gi
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: infisical-storage
   nfs:
@@ -34,7 +34,7 @@ metadata:
   namespace: infisical
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   storageClassName: infisical-storage
   resources:
     requests:

--- a/apps/infisical/pvc.yaml
+++ b/apps/infisical/pvc.yaml
@@ -1,0 +1,42 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: infisical-storage
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: "192.168.86.44"
+  share: "/mnt/tank/db/infisical"
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: infisical-postgres-pv
+  namespace: infisical
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: infisical-storage
+  nfs:
+    server: 192.168.86.44
+    path: /mnt/tank/db/infisical
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: infisical-postgres-pvc
+  namespace: infisical
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: infisical-storage
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: infisical-postgres-pv

--- a/apps/infisical/redis-deployment.yaml
+++ b/apps/infisical/redis-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infisical-redis
+  namespace: infisical
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infisical-redis
+  template:
+    metadata:
+      labels:
+        app: infisical-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5

--- a/apps/infisical/redis-svc.yaml
+++ b/apps/infisical/redis-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: infisical-redis
+  namespace: infisical
+spec:
+  selector:
+    app: infisical-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/apps/infisical/service.yaml
+++ b/apps/infisical/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: infisical
+  namespace: infisical
+  labels:
+    app: infisical
+spec:
+  type: ClusterIP
+  selector:
+    app: infisical
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## Summary

Adds a self-hosted Infisical secrets manager deployment to the cluster, following the standard application pattern with Kustomize and ArgoCD integration. The deployment includes the Infisical backend, PostgreSQL database with persistent NFS storage, and Redis cache.

## Key Changes

- **Main application** (`deployment.yaml`): Infisical v0.160.7 backend + UI on port 8080, with database migration initContainer and health probes
- **PostgreSQL database** (`postgres-deployment.yaml`): Persistent deployment using `postgres:16-alpine` with NFS-backed PVC
- **Redis cache** (`redis-deployment.yaml`): Ephemeral in-cluster Redis for queuing/caching
- **Storage** (`pvc.yaml`): NFS StorageClass and PersistentVolume pointing to `192.168.86.44:/mnt/tank/db/infisical`
- **Configuration** (`configmap.yaml`): Environment variables for production setup, SMTP (Resend), Redis, and database
- **Secrets** (`externalsecret.yaml`): ExternalSecret pulling encryption key, auth secret, database credentials, and SMTP credentials from Doppler
- **Networking** (`http-route.yaml`): Gateway API HTTPRoute exposing the app at `infisical.hoytlabs.app`
- **Services**: ClusterIP services for Infisical, PostgreSQL, and Redis
- **Documentation** (`README.md`): Setup instructions, required Doppler secrets, and prerequisites

## Implementation Details

- Database migrations run automatically via `migration` initContainer on every rollout/upgrade (idempotent via `npm run migration:latest`)
- `wait-for-postgres` initContainer gates startup until PostgreSQL is ready
- Encryption key and auth secret are stable per the Infisical requirement (must not rotate)
- SMTP configured for Resend with credentials from Doppler, email from `infisical@support.hoytlabs.app`
- Resource requests/limits: 200m CPU / 512Mi memory (requests), 1 CPU / 1Gi memory (limits)
- Auto-discovered by `apps/appset.yaml` for GitOps deployment

https://claude.ai/code/session_01H4wWpoMcoNqfRScp7qrKQS