### PR TITLE
fix(infisical): let postgres init on NFS by removing securityContext

### DIFF
--- a/apps/infisical/postgres-deployment.yaml
+++ b/apps/infisical/postgres-deployment.yaml
@@ -16,10 +16,10 @@ spec:
       labels:
         app: infisical-postgres
     spec:
-      securityContext:
-        runAsUser: 70
-        runAsGroup: 70
-        fsGroup: 70
+      # No securityContext: the postgres image entrypoint must start as root so
+      # it can create/chown PGDATA on the NFS-backed volume (NFS ignores fsGroup,
+      # and the export root isn't writable by uid 70). It drops to the postgres
+      # user itself afterward. Matches the working orbit postgres pattern.
       containers:
         - name: postgres
           image: postgres:16-alpine


### PR DESCRIPTION
## Problem

The `infisical-postgres` pod CrashLoops on first start:

```
mkdir: can't create directory '/var/lib/postgresql/data/pgdata': Permission denied
```

The deployment pinned the pod to uid/gid **70** via `securityContext`
(`runAsUser`/`runAsGroup`/`fsGroup: 70`). On NFS, `fsGroup` is **not** honored,
and the export root (`192.168.86.44:/mnt/tank/db/infisical`) is owned by root,
so uid 70 can't create the `pgdata` subdirectory → Postgres never initializes →
the `infisical` app stays stuck in `Init` (waiting on Postgres).

## Fix

Remove the `securityContext` block. The official `postgres` image entrypoint
starts as **root**, creates/chowns `PGDATA`, then drops to the postgres user on
its own — which is exactly how the **working `orbit` Postgres** runs on this same
NFS server (it has no `securityContext`).

No NAS-side changes needed; the failed `mkdir` wrote nothing, so the volume
initializes cleanly once the pod can write.

## Verification
- `kubectl kustomize apps/infisical` renders 13 resources, no `securityContext` on the Postgres deployment.
- Once merged, ArgoCD auto-syncs (`prune`/`selfHeal`); the Postgres Deployment rolls a new pod that initializes the DB, `wait-for-postgres` + `migration` init containers proceed, and the `infisical` app comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)